### PR TITLE
Don't instantiate Cinder v2 (F37+ fix)

### DIFF
--- a/resalloc_openstack/helpers.py
+++ b/resalloc_openstack/helpers.py
@@ -32,8 +32,11 @@ find_id_broken = 'NOVA_BROKEN_SERVER_FIND_ID' in os.environ
 
 neutron = neutron_client.Client(session=session)
 nova = nova_client.Client(2, session=session)
-cinder = cinder_client.Client(2, session=session)
-cinder3 = cinder_client.Client(3, session=session)
+
+try:
+    cinder = cinder_client.Client(3, session=session)
+except:  # pylint: disable=bare-except
+    cinder = cinder_client.Client(2, session=session)
 
 def get_log(name):
     level = logging.DEBUG

--- a/resalloc_openstack/list.py
+++ b/resalloc_openstack/list.py
@@ -20,7 +20,7 @@ import os
 import re
 import sys
 
-from resalloc_openstack.helpers import nova, cinder3
+from resalloc_openstack.helpers import nova, cinder
 
 DESCRIPTION = """
 List a set of OpenStack VMs given the --pool NAME (starting part of the VM
@@ -67,7 +67,7 @@ def main():
         if server.name.startswith(args.pool):
             servers.add(server.name)
 
-    for volume in cinder3.volumes.list():
+    for volume in cinder.volumes.list():
         if volume.name.startswith(args.pool):
             # for pool
             # copr_vm_devel_psi_os


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/resalloc-openstack-new", line 19, in <module>
    from resalloc_openstack.new.main import main
  File "/usr/lib/python3.11/site-packages/resalloc_openstack/new/main.py", line 22, in <module>
    from resalloc_openstack.helpers \
  File "/usr/lib/python3.11/site-packages/resalloc_openstack/helpers.py", line 35, in <module>
    cinder = cinder_client.Client(2, session=session)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/cinderclient/client.py", line 851, in Client
    api_version, client_class = _get_client_class_and_version(version)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/cinderclient/client.py", line 761, in _get_client_class_and_version
    version = api_versions.get_api_version(version)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/cinderclient/api_versions.py", line 231, in get_api_version
    check_major_version(api_version)
  File "/usr/lib/python3.11/site-packages/cinderclient/api_versions.py", line 216, in check_major_version
    raise exceptions.UnsupportedVersion(msg)
cinderclient.exceptions.UnsupportedVersion: Invalid client version '2.0'. Major part should be '3'