### PR TITLE
block stdin because of ansible checks

### DIFF
--- a/resalloc_openstack/new/main.py
+++ b/resalloc_openstack/new/main.py
@@ -17,12 +17,12 @@
 import os
 from time import sleep
 
+from subprocess import check_call, DEVNULL
+
 from .arg_parser import parser
-from resalloc_openstack.env_credentials import session
 from resalloc_openstack.helpers \
         import FloatingIP, random_id, Server, get_log, Volume, GarbageCollector
 from resalloc_openstack.helpers import cinder, nova, neutron, find_id_broken
-from subprocess import check_call
 
 log = get_log(__name__)
 
@@ -128,7 +128,7 @@ def main():
             env = os.environ
             env['RESALLOC_OS_NAME'] = server_name
             env['RESALLOC_OS_IP'] = ipaddr
-            check_call(args.command, env=env, shell=True)
+            check_call(args.command, env=env, shell=True, stdin=DEVNULL)
 
         if args.print_ip:
             print(ipaddr)


### PR DESCRIPTION
If ansible command is passed to --post-command, then it would fail with "ERROR: Ansible requires blocking IO on stdin/stdout/stderr. Non-blocking file handles detected: <stdin>" error. This is due to new feature in ansible [1] where ansible requires blocked stdin because it is executed inside non-interactive environment (subprocess.check_call). Sending PIPE to stdin would block it.

[1]- https://github.com/ansible/ansible/issues/77660